### PR TITLE
Add assert statements

### DIFF
--- a/src/main/java/atlas/Atlas.java
+++ b/src/main/java/atlas/Atlas.java
@@ -10,12 +10,6 @@ import atlas.exceptions.AtlasException;
  * Chatbot implementation
  */
 public class Atlas {
-    static final String LOGO = "        _______ _                _____ \n"
-            + "     /\\|__   __| |        /\\    / ____|\n"
-            + "    /  \\  | |  | |       /  \\  | (___  \n"
-            + "   / /\\ \\ | |  | |      / /\\ \\  \\___ \\ \n"
-            + "  / ____ \\| |  | |____ / ____ \\ ____) |\n"
-            + " /_/    \\_\\_|  |______/_/    \\_\\_____/ \n";
     private final TaskList taskList;
     private final Storage storage;
     private final Parser parser;

--- a/src/main/java/atlas/Main.java
+++ b/src/main/java/atlas/Main.java
@@ -13,12 +13,16 @@ import javafx.stage.Stage;
  * Main class for initialising Atlas's GUI
  */
 public class Main extends Application {
-    private final Atlas atlas = new Atlas("./data/", "atlas.txt");
+    static final String SAVE_FILE_DIRECTORY = "./data/";
+    static final String SAVE_FILE_NAME = "atlas.txt";
+
+    static final String FXML_FILE_PATH = "/view/MainWindow.fxml";
+    private final Atlas atlas = new Atlas(SAVE_FILE_DIRECTORY, SAVE_FILE_NAME);
 
     @Override
     public void start(Stage stage) {
         try {
-            FXMLLoader fxmlLoader = new FXMLLoader(Main.class.getResource("/view/MainWindow.fxml"));
+            FXMLLoader fxmlLoader = new FXMLLoader(Main.class.getResource(FXML_FILE_PATH));
             AnchorPane ap = fxmlLoader.load();
             Scene scene = new Scene(ap);
             stage.setScene(scene);

--- a/src/main/java/atlas/commands/AddTaskCommand.java
+++ b/src/main/java/atlas/commands/AddTaskCommand.java
@@ -37,6 +37,8 @@ public class AddTaskCommand extends Command {
 
     @Override
     public String execute(TaskList taskList, Storage storage) {
+        assert taskList != null;
+        assert storage != null;
         try {
             taskList.addTask(task);
             storage.save(taskList);

--- a/src/main/java/atlas/commands/DeleteTaskCommand.java
+++ b/src/main/java/atlas/commands/DeleteTaskCommand.java
@@ -39,6 +39,8 @@ public class DeleteTaskCommand extends Command {
 
     @Override
     public String execute(TaskList taskList, Storage storage) {
+        assert taskList != null;
+        assert storage != null;
         try {
             Task t = taskList.deleteTask(idx);
             storage.save(taskList);

--- a/src/main/java/atlas/commands/FindCommand.java
+++ b/src/main/java/atlas/commands/FindCommand.java
@@ -34,6 +34,7 @@ public class FindCommand extends Command {
 
     @Override
     public String execute(TaskList taskList, Storage storage) {
+        assert taskList != null;
         List<Task> tasksWithKeyword = taskList.getTasksWithKeyword(keyword);
         StringBuilder output = new StringBuilder("Here are the matching tasks in your list:\n");
         int idx = 0;

--- a/src/main/java/atlas/commands/ListByDateCommand.java
+++ b/src/main/java/atlas/commands/ListByDateCommand.java
@@ -34,6 +34,7 @@ public class ListByDateCommand extends Command {
 
     @Override
     public String execute(TaskList taskList, Storage storage) {
+        assert taskList != null;
         List<Task> tasksOnDate = taskList.getTaskOnDate(date);
         StringBuilder output = new StringBuilder("Here are the tasks occurring on " + date + ":\n");
         int idx = 0;

--- a/src/main/java/atlas/commands/ListCommand.java
+++ b/src/main/java/atlas/commands/ListCommand.java
@@ -24,11 +24,13 @@ public class ListCommand extends Command {
 
     @Override
     public String execute(TaskList taskList, Storage storage) {
+        assert taskList != null;
         List<Task> tasks = taskList.getTasks();
         StringBuilder output = new StringBuilder("Here are your tasks:\n");
         int taskIdx = 0;
         for (Task t : tasks) {
             output.append(String.format("%d. %s\n", ++taskIdx, t));
+            assert taskIdx > 0;
         }
         return output.toString();
     }

--- a/src/main/java/atlas/commands/MarkTaskCommand.java
+++ b/src/main/java/atlas/commands/MarkTaskCommand.java
@@ -39,6 +39,8 @@ public class MarkTaskCommand extends Command {
 
     @Override
     public String execute(TaskList taskList, Storage storage) {
+        assert taskList != null;
+        assert storage != null;
         try {
             List<Task> tasksDone = taskList.markTasks(idx);
             storage.save(taskList);

--- a/src/main/java/atlas/commands/UnmarkTaskCommand.java
+++ b/src/main/java/atlas/commands/UnmarkTaskCommand.java
@@ -40,6 +40,8 @@ public class UnmarkTaskCommand extends Command {
 
     @Override
     public String execute(TaskList taskList, Storage storage) {
+        assert taskList != null;
+        assert storage != null;
         try {
             List<Task> tasksNotDone = taskList.unmarkTasks(idx);
             storage.save(taskList);

--- a/src/main/java/atlas/components/Storage.java
+++ b/src/main/java/atlas/components/Storage.java
@@ -23,6 +23,7 @@ public class Storage {
      * @param fileName Name of file to save to
      */
     public Storage(String fileDir, String fileName) {
+        assert fileName.endsWith(".txt");
         this.fileDir = fileDir;
         this.fileName = fileName;
     }
@@ -41,7 +42,8 @@ public class Storage {
                     Task newTask = Parser.parseFileTasks(listReader.nextLine());
                     loadedTasks.add(newTask);
                 } catch (IllegalArgumentException e) {
-                    System.out.println("Load file is corrupted, skipping task");
+                    final String corruptedFileErrorMessage = "Load file is corrupted, skipping task";
+                    System.out.println(corruptedFileErrorMessage);
                 } catch (Parser.UnsupportedTaskType e) {
                     System.out.printf("Unsupported task type %s, skipping task\n", e.getTaskType());
                 }

--- a/src/main/java/atlas/components/TaskList.java
+++ b/src/main/java/atlas/components/TaskList.java
@@ -20,42 +20,56 @@ public class TaskList {
         this.tasks.addAll(tasks);
     }
 
+    /**
+     * Adds a new task into the list
+     * @param newTask Task to be added to the list
+     */
     public void addTask(Task newTask) {
+        assert newTask != null;
         tasks.add(newTask);
     }
 
     /**
      * Marks tasks as done
-     * @param idx One or more 0-based task indices
+     * @param indices One or more 0-based task indices
      * @return Tasks marked as done
      */
-    public List<Task> markTasks(int... idx) {
+    public List<Task> markTasks(int... indices) {
         List<Task> markedTasks = new ArrayList<>();
-        for (int i : idx) {
-            Task selectedTask = tasks.get(i);
-            selectedTask.markDone();
-            markedTasks.add(selectedTask);
+        for (int i : indices) {
+            try {
+                Task selectedTask = tasks.get(i);
+                selectedTask.markDone();
+                markedTasks.add(selectedTask);
+            } catch (IndexOutOfBoundsException e) {
+                System.out.printf("Invalid index %d\n", i);
+            }
         }
         return markedTasks;
     }
 
     /**
      * Marks task as not done
-     * @param idx One or more 0-based task indices
+     * @param indices One or more 0-based task indices
      * @return Tasks marked as undone
      */
-    public List<Task> unmarkTasks(int... idx) {
+    public List<Task> unmarkTasks(int... indices) {
         List<Task> unmarkedTasks = new ArrayList<>();
-        for (int i : idx) {
-            Task selectedTask = tasks.get(i);
-            selectedTask.markNotDone();
-            unmarkedTasks.add(selectedTask);
+        for (int i : indices) {
+            try {
+                Task selectedTask = tasks.get(i);
+                selectedTask.markNotDone();
+                unmarkedTasks.add(selectedTask);
+            } catch (IndexOutOfBoundsException e) {
+                System.out.printf("Invalid index %d\n", i);
+            }
         }
         return unmarkedTasks;
     }
 
     /**
-     * Deletes task from task list
+     * Deletes task from task list. Deleting multiple tasks at once is not supported as deletion is performed
+     * using indices, which might be affected by the deletion of previous indices.
      * @param idx Zero-based index of task to delete
      * @return Task deleted
      */
@@ -70,8 +84,8 @@ public class TaskList {
      * @return Message containing the current task count
      */
     public String getCountString() {
-        return String.format("Now you have %d %s in the list.\n", tasks.size(),
-                tasks.size() == 1 ? "task" : "tasks");
+        final String taskPlurality = tasks.size() == 1 ? "task" : "tasks";
+        return String.format("Now you have %d %s in the list.\n", tasks.size(), taskPlurality);
     }
 
     /**

--- a/src/main/java/atlas/controllers/MainWindow.java
+++ b/src/main/java/atlas/controllers/MainWindow.java
@@ -15,6 +15,9 @@ import javafx.scene.layout.VBox;
  * Atlas's GUI
  */
 public class MainWindow extends AnchorPane {
+    static final String USER_PROFILE_IMG_PATH = "/images/user.png";
+    static final String ATLAS_PROFILE_IMG_PATH = "/images/atlas.png";
+
     @FXML
     private ScrollPane scrollPane;
     @FXML
@@ -27,9 +30,9 @@ public class MainWindow extends AnchorPane {
     private Atlas atlas;
 
     private final Image userImage = new Image(Objects.requireNonNull(this.getClass().getResourceAsStream(
-            "/images/user.png")));
+            USER_PROFILE_IMG_PATH)));
     private final Image atlasImage = new Image(Objects.requireNonNull(this.getClass().getResourceAsStream(
-            "/images/atlas.png")));
+            ATLAS_PROFILE_IMG_PATH)));
 
     @FXML
     public void initialize() {

--- a/src/main/java/atlas/exceptions/AtlasException.java
+++ b/src/main/java/atlas/exceptions/AtlasException.java
@@ -4,6 +4,7 @@ package atlas.exceptions;
  * Exception class for exceptions that terminate the command and meant to be handled by Duke
  */
 public class AtlasException extends RuntimeException {
+    static final String EXCEPTION_MESSAGE_PREFIX = "Sorry, I ran into an error! Here's more info:\n";
 
     /**
      * Constructs a DukeException exception
@@ -15,6 +16,6 @@ public class AtlasException extends RuntimeException {
 
     @Override
     public String getMessage() {
-        return "Sorry, I ran into an error! Here's more info:\n" + super.getMessage();
+        return EXCEPTION_MESSAGE_PREFIX + super.getMessage();
     }
 }

--- a/src/main/java/atlas/tasks/Task.java
+++ b/src/main/java/atlas/tasks/Task.java
@@ -10,13 +10,6 @@ public abstract class Task {
     protected boolean isDone;
 
     /**
-     * Types of events (TODO, DEADLINE, EVENT)
-     */
-    public enum Types {
-        TODO, DEADLINE, EVENT
-    }
-
-    /**
      * Constructs a new Task with description
      * @param name Name of task
      */
@@ -30,8 +23,9 @@ public abstract class Task {
      * @return "X" if task is done, "   " otherwise
      */
     private String getStatusIcon() {
-
-        return this.isDone ? "X" : "   ";
+        final String taskDoneIcon = "X";
+        final String taskNotDoneIcon = "   ";
+        return this.isDone ? taskDoneIcon : taskNotDoneIcon;
     }
 
     /**

--- a/src/test/java/atlas/tasks/DeadlineTest.java
+++ b/src/test/java/atlas/tasks/DeadlineTest.java
@@ -15,7 +15,7 @@ public class DeadlineTest {
     @Test
     public void toString_default() {
         Deadline testDeadline = new Deadline("Test Deadline", testDateTime);
-        assertEquals(testDeadline.toString(), "[D][ ] Test Deadline (by: 25-08-2023 0000)");
+        assertEquals(testDeadline.toString(), "[D][   ] Test Deadline (by: 25-08-2023 0000)");
     }
 
     @Test
@@ -24,7 +24,7 @@ public class DeadlineTest {
         testDeadline.markDone();
         assertEquals(testDeadline.toString(), "[D][X] Test Deadline (by: 25-08-2023 0000)");
         testDeadline.markNotDone();
-        assertEquals(testDeadline.toString(), "[D][ ] Test Deadline (by: 25-08-2023 0000)");
+        assertEquals(testDeadline.toString(), "[D][   ] Test Deadline (by: 25-08-2023 0000)");
     }
 
     @Test

--- a/src/test/java/atlas/tasks/EventTest.java
+++ b/src/test/java/atlas/tasks/EventTest.java
@@ -16,7 +16,7 @@ public class EventTest {
     @Test
     public void toString_default() {
         Event testEvent = new Event("Test Event", testStartTime, testEndTime);
-        assertEquals(testEvent.toString(), "[E][ ] Test Event (from: 25-08-2023 0000 to: 25-08-2023 2359)");
+        assertEquals(testEvent.toString(), "[E][   ] Test Event (from: 25-08-2023 0000 to: 25-08-2023 2359)");
     }
 
     @Test
@@ -25,7 +25,7 @@ public class EventTest {
         testEvent.markDone();
         assertEquals(testEvent.toString(), "[E][X] Test Event (from: 25-08-2023 0000 to: 25-08-2023 2359)");
         testEvent.markNotDone();
-        assertEquals(testEvent.toString(), "[E][ ] Test Event (from: 25-08-2023 0000 to: 25-08-2023 2359)");
+        assertEquals(testEvent.toString(), "[E][   ] Test Event (from: 25-08-2023 0000 to: 25-08-2023 2359)");
 
     }
 

--- a/src/test/java/atlas/tasks/TodoTest.java
+++ b/src/test/java/atlas/tasks/TodoTest.java
@@ -12,7 +12,7 @@ public class TodoTest {
     @Test
     public void toString_default() {
         Todo testTodo = new Todo("Test Todo");
-        assertEquals(testTodo.toString(), "[T][ ] Test Todo");
+        assertEquals(testTodo.toString(), "[T][   ] Test Todo");
     }
 
     @Test
@@ -21,7 +21,7 @@ public class TodoTest {
         testTodo.markDone();
         assertEquals(testTodo.toString(), "[T][X] Test Todo");
         testTodo.markNotDone();
-        assertEquals(testTodo.toString(), "[T][ ] Test Todo");
+        assertEquals(testTodo.toString(), "[T][   ] Test Todo");
     }
 
     @Test


### PR DESCRIPTION
There are no checks for whether the TaskList and Storage objects passed into commands' execute() methods are non-null, causing potential undefined behaviour and errors.

Adding assert statements to the execute() methods allow us to verify that the TaskList and Storage objects passed in are non-null.

Assert statements will cause the program to terminate if encountered, and can be disabled to avoid affecting application performance.