### PR TITLE
Implement ability to set and get reminders

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,9 +1,10 @@
 # Contributors
 
-Display | Name | Github Profile | Homepage
----|:---:|:---:|:---:
-![](https://avatars0.githubusercontent.com/u/22460123?s=100) | Jeffry Lum | [Github](https://github.com/j-lum/) | [Homepage](https://se.kasugano.moe)
-![](https://avatars0.githubusercontent.com/u/1673303?s=100) | Damith C. Rajapakse | [Github](https://github.com/damithc/) | [Homepage](https://www.comp.nus.edu.sg/~damithch/)
+| Display                                                      |        Name         |            Github Profile             |                      Homepage                      |
+|--------------------------------------------------------------|:-------------------:|:-------------------------------------:|:--------------------------------------------------:|
+| ![](https://avatars0.githubusercontent.com/u/22460123?s=100) |     Jeffry Lum      |  [Github](https://github.com/j-lum/)  |        [Homepage](https://se.kasugano.moe)         |
+| ![](https://avatars0.githubusercontent.com/u/1673303?s=100)  | Damith C. Rajapakse | [Github](https://github.com/damithc/) | [Homepage](https://www.comp.nus.edu.sg/~damithch/) |
+
 # I would like to join this list. How can I help the project
 
 For more information, please refer to our [contributor's guide](https://oss-generic.github.io/process/).

--- a/src/main/java/atlas/commands/ListRemindersCommand.java
+++ b/src/main/java/atlas/commands/ListRemindersCommand.java
@@ -1,0 +1,22 @@
+package atlas.commands;
+
+import java.util.List;
+
+import atlas.components.Storage;
+import atlas.components.TaskList;
+import atlas.tasks.Task;
+
+
+/**
+ * Command to return list of reminders
+ */
+public class ListRemindersCommand extends MultiTaskCommand {
+    private static final String OUTPUT_HEADER_MESSAGE = "Here are your reminders:";
+
+    @Override
+    public String execute(TaskList taskList, Storage storage) {
+        assert taskList != null;
+        List<Task> tasks = taskList.getReminders();
+        return generateListOutput(tasks, OUTPUT_HEADER_MESSAGE);
+    }
+}

--- a/src/main/java/atlas/components/TaskList.java
+++ b/src/main/java/atlas/components/TaskList.java
@@ -121,4 +121,18 @@ public class TaskList {
     public List<Task> getTasks() {
         return List.copyOf(tasks);
     }
+
+    /**
+     * Returns all tasks that the user should be reminded of now
+     * @return Tasks that user should be reminded of
+     */
+    public List<Task> getReminders() {
+        List<Task> reminders = new ArrayList<>();
+        for (Task t : tasks) {
+            if (t.shouldSendReminder()) {
+                reminders.add(t);
+            }
+        }
+        return reminders;
+    }
 }

--- a/src/main/java/atlas/tasks/Deadline.java
+++ b/src/main/java/atlas/tasks/Deadline.java
@@ -10,15 +10,26 @@ import atlas.components.Parser;
  */
 public class Deadline extends Task {
 
-    protected LocalDateTime by;
+    private final LocalDateTime by;
 
     /**
      * Constructs a new Deadline object
      * @param name Name of deadline
-     * @param by Date of deadline
+     * @param by Datetime of deadline
      */
     public Deadline(String name, LocalDateTime by) {
         super(name);
+        this.by = by;
+    }
+
+    /**
+     * Constructs a new Deadline object with reminders
+     * @param name Name of deadline
+     * @param by Datetime of deadline
+     * @param reminderStartDate Date starting from which reminders should be sent
+     */
+    public Deadline(String name, LocalDateTime by, LocalDate reminderStartDate) {
+        super(name, reminderStartDate);
         this.by = by;
     }
 
@@ -29,6 +40,11 @@ public class Deadline extends Task {
 
     @Override
     public String generateSaveString() {
+        if (hasReminder()) {
+            assert reminderStartDate != null;
+            return String.format("D | %b | %s /by %s /remind %s", isDone, name,
+                    by.format(Parser.DATETIME_FORMATTER), reminderStartDate.format(Parser.DATE_FORMATTER));
+        }
         return String.format("D | %b | %s /by %s", isDone, name, by.format(Parser.DATETIME_FORMATTER));
     }
 

--- a/src/main/java/atlas/tasks/Event.java
+++ b/src/main/java/atlas/tasks/Event.java
@@ -9,8 +9,8 @@ import atlas.components.Parser;
  * Event is a task with a start time and end time
  */
 public class Event extends Task {
-    protected LocalDateTime startTime;
-    protected LocalDateTime endTime;
+    private final LocalDateTime startTime;
+    private final LocalDateTime endTime;
 
     /**
      * Constructs a new Event object
@@ -24,6 +24,20 @@ public class Event extends Task {
         this.endTime = endTime;
     }
 
+    /**
+     * Constructs a new Event object with reminders
+     * @param name Name of event
+     * @param startTime Start time of event
+     * @param endTime End time of event
+     * @param reminderStartDate Date starting from which reminders should be sent
+     */
+    public Event(String name, LocalDateTime startTime, LocalDateTime endTime,
+                 LocalDate reminderStartDate) {
+        super(name, reminderStartDate);
+        this.startTime = startTime;
+        this.endTime = endTime;
+    }
+
     @Override
     public String toString() {
         return String.format("[E]%s (from: %s to: %s)", super.toString(),
@@ -33,8 +47,15 @@ public class Event extends Task {
 
     @Override
     public String generateSaveString() {
-        return String.format("E | %b | %s /from %s /to %s", isDone, name, startTime.format(
-                Parser.DATETIME_FORMATTER),
+        if (hasReminder()) {
+            assert reminderStartDate != null;
+            return String.format("E | %b | %s /from %s /to %s /remind %s", isDone, name,
+                    startTime.format(Parser.DATETIME_FORMATTER),
+                    endTime.format(Parser.DATETIME_FORMATTER),
+                    reminderStartDate.format(Parser.DATE_FORMATTER));
+        }
+        return String.format("E | %b | %s /from %s /to %s", isDone, name,
+                startTime.format(Parser.DATETIME_FORMATTER),
                 endTime.format(Parser.DATETIME_FORMATTER));
     }
 

--- a/src/main/java/atlas/tasks/Task.java
+++ b/src/main/java/atlas/tasks/Task.java
@@ -2,20 +2,35 @@ package atlas.tasks;
 
 import java.time.LocalDate;
 
+import atlas.components.Parser;
+
 /**
  * A Task is an object with a name and toggleable status
  */
 public abstract class Task {
-    protected String name;
+    protected final String name;
     protected boolean isDone;
+    protected final LocalDate reminderStartDate;
 
     /**
-     * Constructs a new Task with description
+     * Constructs a new Task with description, but with no reminders
      * @param name Name of task
      */
     public Task(String name) {
         this.name = name;
         this.isDone = false;
+        this.reminderStartDate = null;
+    }
+
+    /**
+     * Constructs a new Task with description and reminders
+     * @param name Name of task
+     * @param reminderStartDate Date starting from which reminders should be sent
+     */
+    public Task(String name, LocalDate reminderStartDate) {
+        this.name = name;
+        this.isDone = false;
+        this.reminderStartDate = reminderStartDate;
     }
 
     /**
@@ -55,8 +70,12 @@ public abstract class Task {
 
     @Override
     public String toString() {
-
-        return String.format("[%s] %s", this.getStatusIcon(), this.getName());
+        if (hasReminder()) {
+            assert reminderStartDate != null;
+            return String.format("[%s] %s (remind starting from: %s)", getStatusIcon(),
+                    getName(), reminderStartDate.format(Parser.DATE_FORMATTER));
+        }
+        return String.format("[%s] %s", getStatusIcon(), getName());
     }
 
     /**
@@ -80,5 +99,29 @@ public abstract class Task {
      */
     public boolean hasKeyword(String keyword) {
         return name.contains(keyword);
+    }
+
+    /**
+     * Returns whether the user should be reminded about this task
+     * @return True if user should be reminded, false otherwise
+     */
+    public boolean shouldSendReminder() {
+        if (hasReminder()) {
+            boolean isTaskUncompleted = !isDone;
+            LocalDate today = LocalDate.now();
+            assert reminderStartDate != null;
+            boolean isTimeForReminders = !reminderStartDate.isAfter(today);
+
+            return isTaskUncompleted && isTimeForReminders;
+        }
+        return false;
+    }
+
+    /**
+     * Returns whether the user has set a reminder for this task
+     * @return True if a reminder has been set, false otherwise
+     */
+    protected boolean hasReminder() {
+        return reminderStartDate != null;
     }
 }

--- a/src/main/java/atlas/tasks/Todo.java
+++ b/src/main/java/atlas/tasks/Todo.java
@@ -1,5 +1,9 @@
 package atlas.tasks;
 
+import java.time.LocalDate;
+
+import atlas.components.Parser;
+
 /**
  * Todo is a Task with no dates
  */
@@ -13,6 +17,15 @@ public class Todo extends Task {
     }
 
     /**
+     * Constructs a new Todo object with reminders
+     * @param name Name of Todo
+     * @param reminderStartDate Date starting from which reminders should be sent
+     */
+    public Todo(String name, LocalDate reminderStartDate) {
+        super(name, reminderStartDate);
+    }
+
+    /**
      * Return string representation of Todo
      * @return String representation of Todo
      */
@@ -22,6 +35,11 @@ public class Todo extends Task {
 
     @Override
     public String generateSaveString() {
+        if (hasReminder()) {
+            assert reminderStartDate != null;
+            return String.format("T | %b | %s /remind %s", isDone, name,
+                    reminderStartDate.format(Parser.DATE_FORMATTER));
+        }
         return String.format("T | %b | %s", isDone, name);
     }
 }

--- a/src/test/java/atlas/tasks/DeadlineTest.java
+++ b/src/test/java/atlas/tasks/DeadlineTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 
 public class DeadlineTest {
     final LocalDateTime testDateTime = LocalDateTime.parse("2023-08-25T00:00:00");
+    final LocalDate testReminderStartDate = LocalDate.parse("2023-09-14");
 
     @Test
     public void toString_default() {
@@ -28,16 +29,33 @@ public class DeadlineTest {
     }
 
     @Test
-    public void generateSaveString_unchecked() {
+    public void generateSaveString_unchecked_noReminder() {
         Deadline testDeadline = new Deadline("Test Deadline", testDateTime);
+        testDeadline.markNotDone();
         assertEquals(testDeadline.generateSaveString(), "D | false | Test Deadline /by 25-08-2023 0000");
     }
 
     @Test
-    public void generateSaveString_checked() {
+    public void generateSaveString_checked_noReminder() {
         Deadline testDeadline = new Deadline("Test Deadline", testDateTime);
         testDeadline.markDone();
         assertEquals(testDeadline.generateSaveString(), "D | true | Test Deadline /by 25-08-2023 0000");
+    }
+
+    @Test
+    public void generateSaveString_unchecked_reminder() {
+        Deadline testDeadline = new Deadline("Test Deadline", testDateTime, testReminderStartDate);
+        testDeadline.markNotDone();
+        assertEquals(testDeadline.generateSaveString(),
+                "D | false | Test Deadline /by 25-08-2023 0000 /remind 14-09-2023");
+    }
+
+    @Test
+    public void generateSaveString_checked_reminder() {
+        Deadline testDeadline = new Deadline("Test Deadline", testDateTime, testReminderStartDate);
+        testDeadline.markDone();
+        assertEquals(testDeadline.generateSaveString(),
+                "D | true | Test Deadline /by 25-08-2023 0000 /remind 14-09-2023");
     }
 
     @Test
@@ -49,5 +67,47 @@ public class DeadlineTest {
         assertFalse(testDeadline.isOccurringOnDate(testDate1));
         assertTrue(testDeadline.isOccurringOnDate(testDate2));
         assertFalse(testDeadline.isOccurringOnDate(testDate3));
+    }
+
+    @Test
+    public void shouldSendReminder_unchecked() {
+        LocalDate pastDate = LocalDate.now().minusDays(7);
+        Deadline testDeadlinePast = new Deadline("Test Deadline with Past Reminder Start Date",
+                testDateTime, pastDate);
+        testDeadlinePast.markNotDone();
+        assertTrue(testDeadlinePast.shouldSendReminder());
+
+        LocalDate today = LocalDate.now();
+        Deadline testDeadlineToday = new Deadline("Test Deadline with Present Reminder Start Date",
+                testDateTime, today);
+        testDeadlineToday.markNotDone();
+        assertTrue(testDeadlineToday.shouldSendReminder());
+
+        LocalDate futureDate = LocalDate.now().plusDays(7);
+        Deadline testDeadlineFuture = new Deadline("Test Deadline with Future Reminder Start Date",
+                testDateTime, futureDate);
+        testDeadlineFuture.markNotDone();
+        assertFalse(testDeadlineFuture.shouldSendReminder());
+    }
+
+    @Test
+    public void shouldSendReminder_checked() {
+        LocalDate pastDate = LocalDate.now().minusDays(7);
+        Deadline testDeadlinePast = new Deadline("Test Deadline with Past Reminder Start Date",
+                testDateTime, pastDate);
+        testDeadlinePast.markDone();
+        assertFalse(testDeadlinePast.shouldSendReminder());
+
+        LocalDate today = LocalDate.now();
+        Deadline testDeadlineToday = new Deadline("Test Deadline with Present Reminder Start Date",
+                testDateTime, today);
+        testDeadlineToday.markDone();
+        assertFalse(testDeadlineToday.shouldSendReminder());
+
+        LocalDate futureDate = LocalDate.now().plusDays(7);
+        Deadline testDeadlineFuture = new Deadline("Test Deadline with Future Reminder Start Date",
+                testDateTime, futureDate);
+        testDeadlineFuture.markDone();
+        assertFalse(testDeadlineFuture.shouldSendReminder());
     }
 }

--- a/src/test/java/atlas/tasks/EventTest.java
+++ b/src/test/java/atlas/tasks/EventTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.Test;
 public class EventTest {
     final LocalDateTime testStartTime = LocalDateTime.parse("2023-08-25T00:00:00");
     final LocalDateTime testEndTime = LocalDateTime.parse("2023-08-25T23:59:59");
+    final LocalDate testReminderStartDate = LocalDate.parse("2023-09-14");
 
     @Test
     public void toString_default() {
@@ -30,18 +31,35 @@ public class EventTest {
     }
 
     @Test
-    public void generateSaveString_unchecked() {
+    public void generateSaveString_unchecked_noReminder() {
         Event testEvent = new Event("Test Event", testStartTime, testEndTime);
+        testEvent.markNotDone();
         assertEquals(testEvent.generateSaveString(), "E | false | Test Event /from 25-08-2023 0000 "
                 + "/to 25-08-2023 2359");
     }
 
     @Test
-    public void generateSaveString_checked() {
+    public void generateSaveString_checked_noReminder() {
         Event testEvent = new Event("Test Event", testStartTime, testEndTime);
         testEvent.markDone();
         assertEquals(testEvent.generateSaveString(), "E | true | Test Event /from 25-08-2023 0000 "
                 + "/to 25-08-2023 2359");
+    }
+
+    @Test
+    public void generateSaveString_unchecked_reminder() {
+        Event testEvent = new Event("Test Event", testStartTime, testEndTime, testReminderStartDate);
+        testEvent.markNotDone();
+        assertEquals(testEvent.generateSaveString(),
+                "E | false | Test Event /from 25-08-2023 0000 /to 25-08-2023 2359 /remind 14-09-2023");
+    }
+
+    @Test
+    public void generateSaveString_checked_reminder() {
+        Event testEvent = new Event("Test Event", testStartTime, testEndTime, testReminderStartDate);
+        testEvent.markDone();
+        assertEquals(testEvent.generateSaveString(),
+                "E | true | Test Event /from 25-08-2023 0000 /to 25-08-2023 2359 /remind 14-09-2023");
     }
 
     @Test
@@ -53,5 +71,47 @@ public class EventTest {
         assertFalse(testEvent.isOccurringOnDate(testDate1));
         assertTrue(testEvent.isOccurringOnDate(testDate2));
         assertFalse(testEvent.isOccurringOnDate(testDate3));
+    }
+
+    @Test
+    public void shouldSendReminder_unchecked() {
+        LocalDate pastDate = LocalDate.now().minusDays(7);
+        Event testEventPast = new Event("Test Event with Past Reminder Start Date",
+                testStartTime, testEndTime, pastDate);
+        testEventPast.markNotDone();
+        assertTrue(testEventPast.shouldSendReminder());
+
+        LocalDate today = LocalDate.now();
+        Event testEventToday = new Event("Test Event with Present Reminder Start Date",
+                testStartTime, testEndTime, today);
+        testEventToday.markNotDone();
+        assertTrue(testEventToday.shouldSendReminder());
+
+        LocalDate futureDate = LocalDate.now().plusDays(7);
+        Event testEventFuture = new Event("Test Event with Future Reminder Start Date",
+                testStartTime, testEndTime, futureDate);
+        testEventFuture.markNotDone();
+        assertFalse(testEventFuture.shouldSendReminder());
+    }
+
+    @Test
+    public void shouldSendReminder_checked() {
+        LocalDate pastDate = LocalDate.now().minusDays(7);
+        Event testEventPast = new Event("Test Event with Past Reminder Start Date",
+                testStartTime, testEndTime, pastDate);
+        testEventPast.markDone();
+        assertFalse(testEventPast.shouldSendReminder());
+
+        LocalDate today = LocalDate.now();
+        Event testEventToday = new Event("Test Event with Present Reminder Start Date",
+                testStartTime, testEndTime, today);
+        testEventToday.markDone();
+        assertFalse(testEventToday.shouldSendReminder());
+
+        LocalDate futureDate = LocalDate.now().plusDays(7);
+        Event testEventFuture = new Event("Test Event with Future Reminder Start Date",
+                testStartTime, testEndTime, futureDate);
+        testEventFuture.markDone();
+        assertFalse(testEventFuture.shouldSendReminder());
     }
 }

--- a/src/test/java/atlas/tasks/TodoTest.java
+++ b/src/test/java/atlas/tasks/TodoTest.java
@@ -2,12 +2,14 @@ package atlas.tasks;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.LocalDate;
 
 import org.junit.jupiter.api.Test;
 
 public class TodoTest {
+    final LocalDate testReminderStartDate = LocalDate.parse("2023-09-14");
 
     @Test
     public void toString_default() {
@@ -25,16 +27,31 @@ public class TodoTest {
     }
 
     @Test
-    public void generateSaveString_unchecked() {
+    public void generateSaveString_unchecked_noReminder() {
         Todo testTodo = new Todo("Test Todo");
+        testTodo.markNotDone();
         assertEquals(testTodo.generateSaveString(), "T | false | Test Todo");
     }
 
     @Test
-    public void generateSaveString_checked() {
+    public void generateSaveString_checked_noReminder() {
         Todo testTodo = new Todo("Test Todo");
         testTodo.markDone();
         assertEquals(testTodo.generateSaveString(), "T | true | Test Todo");
+    }
+
+    @Test
+    public void generateSaveString_unchecked_reminder() {
+        Todo testTodo = new Todo("Test Todo", testReminderStartDate);
+        testTodo.markNotDone();
+        assertEquals(testTodo.generateSaveString(), "T | false | Test Todo /remind 14-09-2023");
+    }
+
+    @Test
+    public void generateSaveString_checked_reminder() {
+        Todo testTodo = new Todo("Test Todo", testReminderStartDate);
+        testTodo.markDone();
+        assertEquals(testTodo.generateSaveString(), "T | true | Test Todo /remind 14-09-2023");
     }
 
     @Test
@@ -44,5 +61,41 @@ public class TodoTest {
         LocalDate testDate2 = LocalDate.parse("2099-12-31");
         assertFalse(testTodo.isOccurringOnDate(testDate1));
         assertFalse(testTodo.isOccurringOnDate(testDate2));
+    }
+
+    @Test
+    public void shouldSendReminder_unchecked() {
+        LocalDate pastDate = LocalDate.now().minusDays(7);
+        Todo testTodoPast = new Todo("Test Todo with Past Reminder Start Date", pastDate);
+        testTodoPast.markNotDone();
+        assertTrue(testTodoPast.shouldSendReminder());
+
+        LocalDate today = LocalDate.now();
+        Todo testTodoToday = new Todo("Test Todo with Present Reminder Start Date", today);
+        testTodoToday.markNotDone();
+        assertTrue(testTodoToday.shouldSendReminder());
+
+        LocalDate futureDate = LocalDate.now().plusDays(7);
+        Todo testTodoFuture = new Todo("Test Todo with Future Reminder Start Date", futureDate);
+        testTodoFuture.markNotDone();
+        assertFalse(testTodoFuture.shouldSendReminder());
+    }
+
+    @Test
+    public void shouldSendReminder_checked() {
+        LocalDate pastDate = LocalDate.now().minusDays(7);
+        Todo testTodoPast = new Todo("Test Todo with Past Reminder Start Date", pastDate);
+        testTodoPast.markDone();
+        assertFalse(testTodoPast.shouldSendReminder());
+
+        LocalDate today = LocalDate.now();
+        Todo testTodoToday = new Todo("Test Todo with Present Reminder Start Date", today);
+        testTodoToday.markDone();
+        assertFalse(testTodoToday.shouldSendReminder());
+
+        LocalDate futureDate = LocalDate.now().plusDays(7);
+        Todo testTodoFuture = new Todo("Test Todo with Future Reminder Start Date", futureDate);
+        testTodoFuture.markDone();
+        assertFalse(testTodoFuture.shouldSendReminder());
     }
 }


### PR DESCRIPTION
There is no way to display a selection of tasks without specifying a specific date, hence users have to read through the entire list of tasks to look for "important tasks".

Adding the ability to set and get reminders allows users to see just the important tasks (defined as tasks not complete and are upcoming).

The option to set a reminder when creating a task hints to Atlas about the task's importance, thus users can be reminded at the appropriate time.